### PR TITLE
Add Brick-Building-Fix and AccountManager

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@ CLIENT_PATH=/Users/someuser/LEGO Universe
 BUILD_THREADS=10
 # Updates NET_VERSION in CMakeVariables.txt
 BUILD_VERSION=171023
+# make sure this is a long random string
+ACCOUNT_MANAGER_SECRET=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,12 @@ services:
       dockerfile: ./docker/brickfix.Dockerfile
     ports:
       - 80:80
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80"]
+      interval: 2m
+      timeout: 3s
+      retries: 3
+      start_period: 40s
 
   account-manager:
     container_name: DarkFlameAccountManager
@@ -57,6 +63,12 @@ services:
       - ACCOUNT_SECRET=${ACCOUNT_MANAGER_SECRET:?err}
     ports:
       - 5000:5000
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5000"]
+      interval: 2m
+      timeout: 3s
+      retries: 3
+      start_period: 40s
 
 networks:
   darkflame:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,16 @@ services:
     volumes:
       - $CLIENT_PATH:/client
 
+  brickbuildfix:
+    container_name: DarkFlameBrickBuildFix
+    networks:
+      - darkflame
+    build:
+      context: .
+      dockerfile: ./docker/brickfix.Dockerfile
+    ports:
+      - 80:80
+
 networks:
   darkflame:
     

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       - DATABASE_HOST=database
       - DATABASE_USER=${MARIADB_USER:-darkflame}
       - DATABASE_PASSWORD=${MARIADB_PASSWORD:-darkflame}
+      - ACCOUNT_SECRET=${ACCOUNT_MANAGER_SECRET:?err}
     ports:
       - 5000:5000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,19 @@ services:
     ports:
       - 80:80
 
+  account-manager:
+    container_name: DarkFlameAccountManager
+    build:
+      context: .
+      dockerfile: ./docker/AccountManager.Dockerfile
+    environment:
+      - DATABASE=${MARIADB_DATABASE:-darkflame}
+      - DATABASE_HOST=database
+      - DATABASE_USER=${MARIADB_USER:-darkflame}
+      - DATABASE_PASSWORD=${MARIADB_PASSWORD:-darkflame}
+    ports:
+      - 5000:5000
+
 networks:
   darkflame:
     

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,8 @@ services:
 
   account-manager:
     container_name: DarkFlameAccountManager
+    networks:
+      - darkflame
     build:
       context: .
       dockerfile: ./docker/AccountManager.Dockerfile

--- a/docker/AccountManager.Dockerfile
+++ b/docker/AccountManager.Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1
+FROM python:3.9.9-buster
+
+WORKDIR /usr/local/share/
+RUN git clone https://github.com/DarkflameUniverse/AccountManager
+
+WORKDIR AccountManager
+ADD docker/credentials_example.py credentials.py
+ADD docker/resources_example.py resources.py
+RUN pip3 install -r requirements.txt && echo "SECRET_KEY = r'$(openssl rand -base64 30)'" >> credentials.py
+
+EXPOSE 5000
+HEALTHCHECK --interval=2m --timeout=3s \
+        CMD curl -f http://localhost:5000 || exit 1
+CMD python3 app.py

--- a/docker/AccountManager.Dockerfile
+++ b/docker/AccountManager.Dockerfile
@@ -10,6 +10,4 @@ ADD docker/resources_example.py resources.py
 RUN pip3 install -r requirements.txt
 
 EXPOSE 5000
-HEALTHCHECK --interval=2m --timeout=3s \
-        CMD curl -f http://localhost:5000 || exit 1
 CMD python3 app.py

--- a/docker/AccountManager.Dockerfile
+++ b/docker/AccountManager.Dockerfile
@@ -7,7 +7,7 @@ RUN git clone https://github.com/DarkflameUniverse/AccountManager
 WORKDIR AccountManager
 ADD docker/credentials_example.py credentials.py
 ADD docker/resources_example.py resources.py
-RUN pip3 install -r requirements.txt && echo "SECRET_KEY = r'$(openssl rand -base64 30)'" >> credentials.py
+RUN pip3 install -r requirements.txt
 
 EXPOSE 5000
 HEALTHCHECK --interval=2m --timeout=3s \

--- a/docker/brickfix.Dockerfile
+++ b/docker/brickfix.Dockerfile
@@ -2,6 +2,4 @@
 FROM python:3.9.9-slim
 WORKDIR /empty_dir
 EXPOSE 80
-HEALTHCHECK --interval=2m --timeout=3s \
-        CMD curl -f http://localhost:80 || exit 1
 CMD python -m http.server 80

--- a/docker/brickfix.Dockerfile
+++ b/docker/brickfix.Dockerfile
@@ -1,0 +1,7 @@
+# syntax=docker/dockerfile:1
+FROM python:3.9.9-slim
+WORKDIR /empty_dir
+EXPOSE 80
+HEALTHCHECK --interval=2m --timeout=3s \
+        CMD curl -f http://localhost:80 || exit 1
+CMD python -m http.server 80

--- a/docker/credentials_example.py
+++ b/docker/credentials_example.py
@@ -1,0 +1,3 @@
+import os
+
+DB_URL = f'mysql+pymysql://{os.environ["DATABASE_USER"]}:{os.environ["DATABASE_PASSWORD"]}@{os.environ["DATABASE_HOST"]}/{os.environ["DATABASE"]}'

--- a/docker/credentials_example.py
+++ b/docker/credentials_example.py
@@ -1,3 +1,4 @@
 import os
 
 DB_URL = f'mysql+pymysql://{os.environ["DATABASE_USER"]}:{os.environ["DATABASE_PASSWORD"]}@{os.environ["DATABASE_HOST"]}/{os.environ["DATABASE"]}'
+SECRET_KEY = os.environ["ACCOUNT_SECRET"]

--- a/docker/resources_example.py
+++ b/docker/resources_example.py
@@ -1,0 +1,3 @@
+LOGO = 'logo/logo.png'
+PRIVACY_POLICY = 'policy/Privacy Policy.pdf'
+TERMS_OF_USE = 'policy/Terms of Use.pdf'


### PR DESCRIPTION
This is pretty much the same as https://github.com/jgkawell/DarkflameServer/pull/2

- The secret for the AccountManager is generated at build time, if we want to distribute finished images, this should instead run at the first start of the container.
- The python server for brick building runs in an empty dir so it doesn't serve any files.
- The paths to the Privacy Policy and such can be edited in docker/resources_example.py.
- I tried using the slim python version for AccountManager, but this didn't have git and apt did not work, so I used the buster version.