### PR TITLE
DB migrations from volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - MARIADB_DATABASE=${MARIADB_DATABASE:-darkflame}
     volumes:
       - database:/var/lib/mysql
+      - migrations/dlu:/docker-entrypoint-initdb.d
     networks:
       - darkflame
 

--- a/docker/start_server.sh
+++ b/docker/start_server.sh
@@ -80,17 +80,6 @@ function fdb_to_sqlite() {
     )
 }
 
-function run_db_migrations() {
-    (
-        cd /app/migrations/dlu
-        readarray -d '' entries < <(printf '%s\0' *.sql | sort -zV)
-        for entry in "${entries[@]}"; do
-            echo "Execute $entry"
-            mysql -h"$DATABASE_HOST" -P"$DATABASE_PORT" -u"$DATABASE_USER" -p"$DATABASE_PASSWORD" $DATABASE < $entry
-        done
-    )
-}
-
 set_defaults
 
 check_sql_connection
@@ -117,8 +106,6 @@ fi
 symlink_client_files
 
 fdb_to_sqlite
-
-run_db_migrations
 
 echo "Start MasterServer"
 


### PR DESCRIPTION
This change makes the DB perform the migrations instead of needing the bootup script. 

FYI: Haven't tested this. Will be able to later today though.