### PR TITLE
Readme: Add Git installation instructions

### DIFF
--- a/Docker_Windows.md
+++ b/Docker_Windows.md
@@ -19,15 +19,18 @@
 
 ![Disable Autostart](docker/images/DD_General_Settings.png)
 
-8. Download the DarkflameServer repository and extract it to a location of your choice.
-9. Inside the extracted folder, copy `.env.example` and name the copy `.env`
-10. Open `.env` with notepad by right-clicking it and selecting _Open With_ -> _More apps_ -> _Notepad_.
-11. Change the text after `CLIENT_PATH=` to the location of your client. The folder you are pointing to must contain a folder called `client` which should contain the client files. Use `/` instead of `\`. For example, if you have `legouniverse.exe` at `C:\Users\someone\Downloads\LU\client\legouniverse.exe`, enter `C:/Users/someone/Downloads/LU`
-12. Optionally, you can change the number after `BUILD_THREADS=` to the number of cores / threads your processor has. If your computer crashes while building, you can try to reduce this value.
-13. After `ACCOUNT_MANAGER_SECRET=` paste a "SHA 256-bit Key" from https://keygen.io/
-14. If you are not only hosting a local server, change the value after `EXTERNAL_IP=` to the external IP address of your computer.
-15. Change the two values `SECRET_VALUE_CHANGE_ME` to passwords only you know. Save and close the file.
-16. In the extracted folder hit Shift+Right Click and select "Open PowerShell window here".
+8. Install [Git for Windows](https://git-scm.com/download/win). During the installation, simply confirming the defaults is sufficient.
+9. In the folder you wish to save the Server, right click and select "Git Bash Here".
+10. Type `git clone --recursive https://github.com/DarkflameUniverse/DarkflameServer`
+11. Once the command has completed (you can see you path again and can enter commands), close the window.
+12. Inside the downloaded folder, copy `.env.example` and name the copy `.env`
+13. Open `.env` with notepad by right-clicking it and selecting _Open With_ -> _More apps_ -> _Notepad_.
+14. Change the text after `CLIENT_PATH=` to the location of your client. The folder you are pointing to must contain a folder called `client` which should contain the client files. Use `/` instead of `\`. For example, if you have `legouniverse.exe` at `C:\Users\someone\Downloads\LU\client\legouniverse.exe`, enter `C:/Users/someone/Downloads/LU`
+15. Optionally, you can change the number after `BUILD_THREADS=` to the number of cores / threads your processor has. If your computer crashes while building, you can try to reduce this value.
+16. After `ACCOUNT_MANAGER_SECRET=` paste a "SHA 256-bit Key" from https://keygen.io/
+17. If you are not only hosting a local server, change the value after `EXTERNAL_IP=` to the external IP address of your computer.
+18. Change the two values `SECRET_VALUE_CHANGE_ME` to passwords only you know. Save and close the file.
+19. In the extracted folder hit Shift+Right Click and select "Open PowerShell window here".
 
 ![Open PowerShell](docker/images/Open_Powershell.png)
 


### PR DESCRIPTION
I completely forgot that a normal download from Github does not download submodules. So the user unfortunately has to install Git for recursive cloning. Instructions are added with this pull request.